### PR TITLE
Added new color options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 This is my own copy of i3lock, consisting of the following tweaks: 
-- Changed the display on key-strokes and escape/backspace.
+- Display changes on key-strokes and escape/backspace.
 - Added 12-hour clock to the unlock indicator and periodic updater so time stays relevant. 
-- Changed border, text and background colors.
-- Changed it so that the unlock indicator will always be displayed, regardless of state. (Originally it was only shown after initial keypress) 
-  
+- The unlock indicator will always be displayed, regardless of state. (Originally it was only shown after initial keypress) 
+- **10/17/15** Added command line arguments to customize colors. Each (optional) argument will accept a color in hexadecimal format. 
+  - `-o color` Specifies verification color
+  - `-w color` Specifies wrong password/backspace color
+  - `-l color` Specifies default/idle color
+  - The given colors will be used as-is for the lines and text for their respective states. The colors will automatically be lightened slightly and used with lower opacity (20%) for the circle fill. 
+  - If no colors are specified it defaults to green/red/black for verify/wrong/idle respectively.
+
+## Example Usage
+`i3lock -i ~/.i3/background.png -c '#000000' -o '#191d0f' -w '#572020' -l '#ffffff' -e`
 
 ## Screenshots
+*TODO:* Add screenshots of default behavior. (No colors specified)
 #### Default
 ![Default state](/screenshots/lockscreen.png?raw=true "")
-### Key Press
+#### Key Press
 ![On key press](/screenshots/lockscreenkeypress.png?raw=true "")
-### Escape/Backspace
+#### Escape/Backspace
 ![On escape or backspace](/screenshots/lockscreenesc.png?raw=true "")
 
 <p>

--- a/i3lock.c
+++ b/i3lock.c
@@ -43,7 +43,13 @@
 typedef void (*ev_callback_t)(EV_P_ ev_timer *w, int revents);
 
 /* We need this for libxkbfile */
-char color[7] = "ffffff";
+
+/* Color options */
+char color[7] = "ffffff"; // background
+char verifycolor[7] = "445029"; // verify
+char wrongcolor[7] = "8f3535"; // wrong
+char idlecolor[7] = "ffffff"; // idle
+
 int inactivity_timeout = 30;
 uint32_t last_resolution[2];
 xcb_window_t win;
@@ -658,6 +664,21 @@ static void raise_loop(xcb_window_t window) {
     }
 }
 
+int verify_hex(char *arg, char *colortype, char *varname) {
+    /* Skip # if present */
+    if (arg[0] == '#') {
+        arg++;  
+    }
+        
+    if (strlen(arg) != 6 || sscanf(arg, "%06[0-9a-fA-F]", colortype) != 1) {
+        errx(EXIT_FAILURE, "%s is invalid, it must be given in 3-byte hexadecimal format: rrggbb\n", varname);
+
+        return 0;
+    }
+        
+    return 1;
+}
+
 int main(int argc, char *argv[]) {
     char *username;
     char *image_path = NULL;
@@ -681,13 +702,16 @@ int main(int argc, char *argv[]) {
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
+        {"verify-color", required_argument, NULL, 'o'},
+        {"wrong-color", required_argument, NULL, 'w'},
+        {"idle-color", required_argument, NULL, 'l'},
         {NULL, no_argument, NULL, 0}
     };
 
     if ((username = getenv("USER")) == NULL)
         errx(EXIT_FAILURE, "USER environment variable not set, please set it.\n");
 
-    char *optstring = "hvnbdc:p:ui:teI:f";
+    char *optstring = "hvnbdc:o:w:l:p:ui:teI:f";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
         switch (o) {
         case 'v':
@@ -708,18 +732,18 @@ int main(int argc, char *argv[]) {
             inactivity_timeout = time;
             break;
         }
-        case 'c': {
-            char *arg = optarg;
-
-            /* Skip # if present */
-            if (arg[0] == '#')
-                arg++;
-
-            if (strlen(arg) != 6 || sscanf(arg, "%06[0-9a-fA-F]", color) != 1)
-                errx(EXIT_FAILURE, "color is invalid, it must be given in 3-byte hexadecimal format: rrggbb\n");
-
+        case 'c': 
+            verify_hex(optarg,color, "color");
             break;
-        }
+        case 'o':
+            verify_hex(optarg,verifycolor, "verifycolor");
+            break;
+        case 'w':
+            verify_hex(optarg,wrongcolor, "wrongcolor");
+            break;
+        case 'l':
+            verify_hex(optarg,idlecolor, "idlecolor");
+            break;
         case 'u':
             unlock_indicator = false;
             break;
@@ -749,7 +773,7 @@ int main(int argc, char *argv[]) {
             show_failed_attempts = true;
             break;
         default:
-            errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
+            errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-o color] [-w color] [-l color] [-u] [-p win|default]"
             " [-i image.png] [-t] [-e] [-I] [-f]"
             );
         }

--- a/i3lock.c
+++ b/i3lock.c
@@ -46,9 +46,9 @@ typedef void (*ev_callback_t)(EV_P_ ev_timer *w, int revents);
 
 /* Color options */
 char color[7] = "ffffff"; // background
-char verifycolor[7] = "445029"; // verify
-char wrongcolor[7] = "8f3535"; // wrong
-char idlecolor[7] = "ffffff"; // idle
+char verifycolor[7] = "00ff00"; // verify
+char wrongcolor[7] = "ff0000"; // wrong
+char idlecolor[7] = "000000"; // idle
 
 int inactivity_timeout = 30;
 uint32_t last_resolution[2];

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -25,7 +25,7 @@
 #define BUTTON_SPACE (BUTTON_RADIUS + 5)
 #define BUTTON_CENTER (BUTTON_RADIUS + 5)
 #define BUTTON_DIAMETER (2 * BUTTON_SPACE)
-#define TIME_FORMAT "%l:%M%p"
+#define TIME_FORMAT "%l:%M %p"
 
 /*******************************************************************************
  * Variables defined in i3lock.c.
@@ -150,7 +150,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
 
         switch(colortype) {
             case 'b': /* Background */
-                cairo_set_source_rgba(cr, rgb16[0] / 255.0, rgb16[1] / 255.0, rgb16[2] / 255.0, 1);
+                cairo_set_source_rgb(cr, rgb16[0] / 255.0, rgb16[1] / 255.0, rgb16[2] / 255.0);
                 break;
             case 'l': /* Line and text */
                 cairo_set_source_rgba(cr, rgb16[0] / 255.0, rgb16[1] / 255.0, rgb16[2] / 255.0, 0.8);
@@ -158,12 +158,10 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
             case 'f': /* Fill */
                 /* Use a lighter tint of the user defined color for circle fill */
                 for (int i=0; i < 3; i++) {
-                    rgb16[i] = ((255 - rgb16[i]) * .25) + rgb16[i];
+                    rgb16[i] = ((255 - rgb16[i]) * .5) + rgb16[i];
                 }
                 cairo_set_source_rgba(cr, rgb16[0] / 255.0, rgb16[1] / 255.0, rgb16[2] / 255.0, 0.2);
                 break;
-            case 'n': /* No color, used for default idle */
-                cairo_set_source_rgba(cr,0,0,0,0);
         }
         free(rgb16);
     }
@@ -216,30 +214,12 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                         set_color(ctx,wrongcolor,colortype);
                     }
                     else {
-                        // switch(colortype) {
-                        //     case 'l':
-                        //         set_color(ctx,idlecolor,colortype);
-                        //     case 'f':
-                        //         set_color(ctx,idlecolor,n); /* Empty Background */
-                        // }
                         set_color(ctx,idlecolor,colortype);  
                     }
                     break;
             }
         }
 
-        /* Circle fill */
-        // switch (pam_state) {
-        //     case STATE_PAM_VERIFY:
-        //         cairo_set_source_rgba(ctx, 114.75/255, 123.75/255, 94.5/255, 0.2);
-        //         break;
-        //     case STATE_PAM_WRONG:
-        //         cairo_set_source_rgba(ctx, 172.0/255, 65.0/255, 66.0/255, 0.2);
-        //         break;
-        //     default:
-        //         cairo_set_source_rgba(ctx, 0, 0, 0, 0);
-        //         break;
-        // }
         set_pam_color('f');
         cairo_fill_preserve(ctx);
 


### PR DESCRIPTION
Added command line arguments to customize colors. Each (optional) argument will accept a color in hexadecimal format. The given colors will be used as-is for the lines and text for their respective states. The colors will automatically be lightened slightly and used with lower opacity (20%) for the circle fill. If no colors are specified it defaults to green/red/black for verify/wrong/idle respectively.
