### PR TITLE
Fix unused variable in i3lock.c

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -887,7 +887,7 @@ int main(int argc, char *argv[]) {
 #endif
     int curs_choice = CURS_NONE;
     int o;
-    int longoptind = 0;
+    int optind = 0;
     struct option longopts[] = {
         {"version", no_argument, NULL, 'v'},
         {"nofork", no_argument, NULL, 'n'},


### PR DESCRIPTION
"longoptind" declared as integer and never used but variable "optind" was used further in the code. 